### PR TITLE
CLI and generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # dry-web-roda [![Join the chat at https://gitter.im/dry-rb/chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dry-rb/chat?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+Integration between dry-web and roda.
+
+dry-web-roda offers a CLI for generating new projects:
+
+```sh
+$ dry-web-roda new <project_name>
+```
+
+And building apps within projects:
+
+```sh
+$ dry-web-roda generate app <my_sub_app_name>
+```
+
 ## LICENSE
 
 See `LICENSE` file.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/dry-rb/dry-web.
+Bug reports and pull requests are welcome on GitHub at https://github.com/dry-rb/dry-web-roda.

--- a/bin/dry-web-roda
+++ b/bin/dry-web-roda
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "dry/web/roda/cli"
+
+Dry::Web::Roda::CLI.start ARGV

--- a/dry-web-roda.gemspec
+++ b/dry-web-roda.gemspec
@@ -18,8 +18,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "dry-configurable", "~> 0.1"
+  spec.add_runtime_dependency "inflecto", "~> 0.0"
   spec.add_runtime_dependency "roda", "~> 2.14"
   spec.add_runtime_dependency "roda-flow", "~> 0.3"
+  spec.add_runtime_dependency "thor", "~> 0.19"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 11.0"

--- a/lib/dry/web/roda/cli.rb
+++ b/lib/dry/web/roda/cli.rb
@@ -1,0 +1,15 @@
+require "thor"
+
+module Dry
+  module Web
+    module Roda
+      class CLI < Thor
+        desc "new APP", "Generate a new dry-web-roda project"
+        def new(app_name)
+          require "dry/web/roda/generators/umbrella"
+          Dry::Web::Roda::Generators::Umbrella.new.call(app_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/web/roda/cli.rb
+++ b/lib/dry/web/roda/cli.rb
@@ -7,8 +7,12 @@ module Dry
         desc "new APP", "Generate a new dry-web-roda project"
         def new(app_name)
           require "dry/web/roda/generators/umbrella"
-          Dry::Web::Roda::Generators::Umbrella.new.call(app_name)
+          Generators::Umbrella.new.(app_name)
         end
+
+        desc "generate GENERATOR", "Generate a new component for an existing dry-web-roda project"
+        require "dry/web/roda/cli/generate"
+        subcommand "generate", CLI::Generate
       end
     end
   end

--- a/lib/dry/web/roda/cli/generate.rb
+++ b/lib/dry/web/roda/cli/generate.rb
@@ -1,0 +1,18 @@
+require "thor"
+
+module Dry
+  module Web
+    module Roda
+      class CLI
+        class Generate < Thor
+          desc "generate app APP", "Generate an app within a dry-web umbrella"
+          option :umbrella, required: true, banner: "UMBRELLA_NAME", desc: "Provide the name of the umbrella app, e.g. my_project"
+          def app(app_name)
+            require "dry/web/roda/generators/app"
+            Dry::Web::Roda::Generators::App.new.(app_name, umbrella: options[:umbrella])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/web/roda/generate.rb
+++ b/lib/dry/web/roda/generate.rb
@@ -7,18 +7,15 @@ module Dry
       class Generate
         SKELETONS_DIR = "skeletons".freeze
 
-        class Processor < Thor
-          include Thor::Actions
-        end
-
         attr_reader :source_dir
         attr_reader :processor
 
         def initialize(skeleton_name)
-          @source_dir = Pathname(__dir__).join(SKELETONS_DIR).join(skeleton_name)
+          @source_dir = Pathname(__FILE__).dirname.join(SKELETONS_DIR).join(skeleton_name)
 
-          # TODO: determine if this is a problem across multiple instances
-          @processor = Processor.new
+          @processor = Class.new(Thor) do
+            include Thor::Actions
+          end.new
           @processor.class.source_root source_dir
         end
 

--- a/lib/dry/web/roda/generate.rb
+++ b/lib/dry/web/roda/generate.rb
@@ -1,0 +1,50 @@
+require "pathname"
+require "thor"
+
+module Dry
+  module Web
+    module Roda
+      class Generate
+        SKELETONS_DIR = "skeletons".freeze
+
+        class Processor < Thor
+          include Thor::Actions
+        end
+
+        attr_reader :source_dir
+        attr_reader :processor
+
+        def initialize(skeleton_name)
+          @source_dir = Pathname(__dir__).join(SKELETONS_DIR).join(skeleton_name)
+
+          # TODO: determine if this is a problem across multiple instances
+          @processor = Processor.new
+          @processor.class.source_root source_dir
+        end
+
+        def call(target_dir, scope = {})
+          target_dir = Pathname.getwd + target_dir
+          source_files = Dir[source_dir.join("**/{.,}*")]
+
+          source_files.select { |f| File.file?(f) }.each do |source_file|
+            source_file = Pathname(source_file).relative_path_from(source_dir)
+            target_file = target_dir + source_file
+
+            if scope.any?
+              target_file = target_file.to_s.gsub(/__#{Regexp.union(scope.keys.map(&:to_s))}__/) { |match|
+                scope_key = match.gsub(/^__/, "").gsub(/__$/, "")
+                scope.fetch(scope_key.to_sym)
+              }
+            end
+
+            if source_file.extname == Thor::TEMPLATE_EXTNAME
+              processor.template source_file, target_file.sub(/#{Thor::TEMPLATE_EXTNAME}$/, ""), scope
+            else
+              processor.copy_file source_file, target_file
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/web/roda/generators/app.rb
+++ b/lib/dry/web/roda/generators/app.rb
@@ -1,0 +1,33 @@
+require "inflecto"
+require "dry/web/roda/generate"
+
+module Dry
+  module Web
+    module Roda
+      module Generators
+        class App
+          attr_reader :generate
+
+          def initialize
+            @generate = Dry::Web::Roda::Generate.new("app")
+          end
+
+          def call(target_dir, umbrella_name)
+            generate.call(File.join("apps", target_dir), prepare_scope(target_dir, umbrella_name))
+          end
+
+          private
+
+          def prepare_scope(target_dir, umbrella_name)
+            {
+              underscored_app_name: Inflecto.underscore(target_dir),
+              camel_cased_app_name: Inflecto.camelize(target_dir),
+              underscored_umbrella_name: Inflecto.underscore(umbrella_name),
+              camel_cased_umbrella_name: Inflecto.camelize(umbrella_name),
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/web/roda/generators/app.rb
+++ b/lib/dry/web/roda/generators/app.rb
@@ -12,8 +12,11 @@ module Dry
             @generate = Dry::Web::Roda::Generate.new("app")
           end
 
-          def call(target_dir, umbrella_name)
-            generate.call(File.join("apps", target_dir), prepare_scope(target_dir, umbrella_name))
+          def call(target_dir, options = {})
+            umbrella_name = options.fetch(:umbrella)
+            generate_to = options.fetch(:to) { File.join("apps", target_dir) }
+
+            generate.(generate_to, prepare_scope(target_dir, umbrella_name))
           end
 
           private

--- a/lib/dry/web/roda/generators/umbrella.rb
+++ b/lib/dry/web/roda/generators/umbrella.rb
@@ -1,0 +1,31 @@
+require "inflecto"
+require "dry/web/roda/generate"
+
+module Dry
+  module Web
+    module Roda
+      module Generators
+        class Umbrella
+          attr_reader :generate
+
+          def initialize
+            @generate = Dry::Web::Roda::Generate.new("umbrella")
+          end
+
+          def call(target_dir)
+            generate.call(target_dir, prepare_scope(target_dir))
+          end
+
+          private
+
+          def prepare_scope(target_dir)
+            {
+              underscored_app_name: Inflecto.underscore(target_dir),
+              camel_cased_app_name: Inflecto.camelize(target_dir)
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/web/roda/generators/umbrella.rb
+++ b/lib/dry/web/roda/generators/umbrella.rb
@@ -19,7 +19,7 @@ module Dry
             generate.(target_dir, prepare_scope(target_dir))
 
             Dir.chdir(target_dir) do
-              app_generator.("main", target_dir)
+              app_generator.("main", umbrella: target_dir)
             end
           end
 

--- a/lib/dry/web/roda/generators/umbrella.rb
+++ b/lib/dry/web/roda/generators/umbrella.rb
@@ -1,19 +1,26 @@
 require "inflecto"
+require "securerandom"
 require "dry/web/roda/generate"
+require "dry/web/roda/generators/app"
 
 module Dry
   module Web
     module Roda
       module Generators
         class Umbrella
-          attr_reader :generate
+          attr_reader :generate, :app_generator
 
           def initialize
-            @generate = Dry::Web::Roda::Generate.new("umbrella")
+            @generate = Generate.new("umbrella")
+            @app_generator = Generators::App.new
           end
 
           def call(target_dir)
-            generate.call(target_dir, prepare_scope(target_dir))
+            generate.(target_dir, prepare_scope(target_dir))
+
+            Dir.chdir(target_dir) do
+              app_generator.("main", target_dir)
+            end
           end
 
           private

--- a/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/application.rb.tt
+++ b/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/application.rb.tt
@@ -1,0 +1,33 @@
+require "rack/csrf"
+require "dry/web/roda/application"
+require_relative "container"
+require "roda_plugins"
+
+module <%= config[:camel_cased_app_name] %>
+  class Application < Dry::Web::Roda::Application
+    configure do |config|
+      config.routes = "web/routes".freeze
+      config.container = Container
+    end
+
+    opts[:root] = Pathname(__FILE__).join("../..").realpath.dirname
+
+    use Rack::Session::Cookie, key: "<%= config[:underscored_app_name] %>.session", secret: <%= config[:camel_cased_umbrella_name] %>::Container.settings.session_secret
+    use Rack::Csrf, raise: true
+
+    plugin :flash
+
+    plugin :view
+    plugin :page
+
+    def name
+      :<%= config[:underscored_app_name] %>
+    end
+
+    route do |r|
+      r.multi_route
+    end
+
+    load_routes!
+  end
+end

--- a/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/container.rb.tt
+++ b/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/container.rb.tt
@@ -1,0 +1,19 @@
+require "pathname"
+require "dry/web/container"
+
+module <%= config[:camel_cased_app_name] %>
+  class Container < Dry::Web::Container
+    require root.join("component/<%= config[:underscored_umbrella_name] %>/container")
+    import <%= config[:camel_cased_umbrella_name] %>::Container
+
+    configure do |config|
+      config.root = Pathname(__FILE__).join("../..").realpath.dirname.freeze
+
+      config.auto_register = %w[
+        lib/<%= config[:underscored_app_name] %>
+      ]
+    end
+
+    load_paths! "lib", "component"
+  end
+end

--- a/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/import.rb.tt
+++ b/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/import.rb.tt
@@ -1,0 +1,5 @@
+require_relative "container"
+
+module <%= config[:camel_cased_app_name] %>
+  Import = <%= config[:camel_cased_app_name] %>::Container::Inject
+end

--- a/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/page.rb.tt
+++ b/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/page.rb.tt
@@ -1,0 +1,6 @@
+require "<%= config[:underscored_umbrella_name] %>/page"
+
+module <%= config[:camel_cased_app_name] %>
+  class Page < <%= config[:camel_cased_umbrella_name] %>::Page
+  end
+end

--- a/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/transactions.rb.tt
+++ b/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/transactions.rb.tt
@@ -1,0 +1,12 @@
+require "dry-transaction"
+require "<%= config[:underscored_umbrella_name] %>/transactions"
+require "<%= config[:underscored_app_name] %>/container"
+require "<%= config[:underscored_app_name] %>/import"
+
+module <%= config[:camel_cased_app_name] %>
+  class Transactions < <%= config[:camel_cased_umbrella_name] %>::Transactions
+    configure do |config|
+      config.container = <%= config[:camel_cased_app_name] %>::Container
+    end
+  end
+end

--- a/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/view.rb.tt
+++ b/lib/dry/web/roda/skeletons/app/component/__underscored_app_name__/view.rb.tt
@@ -1,0 +1,19 @@
+require "slim"
+require "dry-view"
+require "<%= config[:underscored_app_name] %>/container"
+require "<%= config[:underscored_app_name] %>/page"
+
+module Main
+  Container.register "page", Page.new
+
+  class View < Dry::View::Layout
+    setting :root, Container.root.join("web/templates")
+    setting :scope, Container["page"]
+    setting :formats, {html: :slim}
+    setting :name, "application"
+
+    def locals(options)
+      super.merge(options[:scope].view_locals)
+    end
+  end
+end

--- a/lib/dry/web/roda/skeletons/app/component/boot.rb.tt
+++ b/lib/dry/web/roda/skeletons/app/component/boot.rb.tt
@@ -1,0 +1,10 @@
+require_relative "main/container"
+
+<%= config[:camel_cased_app_name] %>::Container.finalize! do |container|
+end
+
+require "<%= config[:underscored_app_name] %>/application"
+require "<%= config[:underscored_app_name] %>/view"
+require "<%= config[:underscored_app_name] %>/transactions"
+
+<%= config[:camel_cased_app_name] %>::Container.require "transactions/**/*.rb"

--- a/lib/dry/web/roda/skeletons/app/transactions/example.rb.tt
+++ b/lib/dry/web/roda/skeletons/app/transactions/example.rb.tt
@@ -1,0 +1,9 @@
+require "<%= config[:underscored_app_name] %>/transactions"
+
+<%= config[:camel_cased_app_name] %>::Transactions.define do |t|
+  # Define your dry-transaction objects here:
+  #
+  # t.define "<%= config[:underscored_app_name] %>.transactions.users.sign_up" do
+  #   step :persist, with: "<%= config[:underscored_app_name] %>.users.operations.sign_up"
+  # end
+end

--- a/lib/dry/web/roda/skeletons/app/web/routes/example.rb.tt
+++ b/lib/dry/web/roda/skeletons/app/web/routes/example.rb.tt
@@ -1,0 +1,7 @@
+# Define your routes like this:
+#
+# class <%= config[:camel_cased_app_name] %>::Application
+#   route "example" do |r|
+#     # Routes go here
+#   end
+# end

--- a/lib/dry/web/roda/skeletons/app/web/templates/layouts/application.html.slim
+++ b/lib/dry/web/roda/skeletons/app/web/templates/layouts/application.html.slim
@@ -1,0 +1,3 @@
+html
+  body
+    == yield

--- a/lib/dry/web/roda/skeletons/umbrella/.gitignore
+++ b/lib/dry/web/roda/skeletons/umbrella/.gitignore
@@ -1,0 +1,5 @@
+# Ignore secrets in app settings (copy a version to settings.example.yml if you want to check one in)
+/config/settings.yml
+
+# RSpec
+/spec/examples.txt

--- a/lib/dry/web/roda/skeletons/umbrella/Gemfile
+++ b/lib/dry/web/roda/skeletons/umbrella/Gemfile
@@ -1,0 +1,40 @@
+source "https://rubygems.org"
+
+gem "rake"
+
+# Web framework
+gem "dry-component"
+gem "dry-web"
+gem "dry-web-roda"
+gem "puma"
+gem "rack_csrf"
+gem "shotgun"
+
+# Database persistence
+gem "pg"
+gem "rom",            github: "rom-rb/rom"
+gem "rom-mapper",     github: "rom-rb/rom-mapper"
+gem "rom-repository", github: "rom-rb/rom-repository"
+gem "rom-sql",        github: "rom-rb/rom-sql"
+gem "rom-support",    github: "rom-rb/rom-support"
+
+# Application dependencies
+gem "dry-result_matcher"
+gem "dry-transaction"
+gem "dry-types"
+gem "dry-validation"
+gem "dry-view"
+gem "slim"
+
+group :development, :test do
+  gem "guard-rspec"
+  gem "pry-byebug"
+end
+
+group :test do
+  gem "capybara"
+  gem "capybara-screenshot"
+  gem "database_cleaner"
+  gem "poltergeist"
+  gem "rspec"
+end

--- a/lib/dry/web/roda/skeletons/umbrella/README.md.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/README.md.tt
@@ -1,3 +1,12 @@
 # <%= config[:camel_cased_app_name] %>
 
-You’ve generated an app using dry-web-roda.
+Welcome! You’ve generated an app using dry-web-roda.
+
+## First steps
+
+1. Run `bundle`
+1. Review `config/settings.yml` (and make a copy at `config/settings.example.yml` if you want to keep example settings checked in)
+1. Create a `<%= config[:underscored_app_name] %>_development` database
+1. Add your own steps to `bin/setup`
+1. Run the app with `bundle exec shotgun -p 3000 -o 0.0.0.0 config.ru`
+1. Initialize git with `git init` and make your initial commit

--- a/lib/dry/web/roda/skeletons/umbrella/README.md.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/README.md.tt
@@ -1,0 +1,3 @@
+# <%= config[:camel_cased_app_name] %>
+
+You’ve generated an app using dry-web-roda.

--- a/lib/dry/web/roda/skeletons/umbrella/Rakefile.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/Rakefile.tt
@@ -1,0 +1,81 @@
+require "bundler/setup"
+
+require "byebug" unless ENV["RACK_ENV"] == "production"
+
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new :spec
+  task default: [:spec]
+rescue LoadError
+end
+
+require_relative "component/<%= config[:underscored_app_name] %>/container"
+
+require "rom/sql/rake_task"
+require "sequel"
+namespace :db do
+  task :setup do
+    <%= config[:camel_cased_app_name] %>::Container.boot! :rom
+  end
+
+  # The following migration tasks are adapted from https://gist.github.com/kalmbach/4471560
+  Sequel.extension :migration
+  DB = Sequel.connect(<%= config[:camel_cased_app_name] %>::Container.settings.database_url)
+
+  desc "Prints current schema version"
+  task :version do
+    version = if DB.tables.include?(:schema_migrations)
+      DB[:schema_migrations].order(:filename).last[:filename]
+    end || "not available"
+
+    puts "Current schema version: #{version}"
+  end
+
+  namespace :structure do
+    desc "Dump database structure to db/structure.sql"
+    task :dump do
+      require "uri"
+      uri = URI(DB.url)
+
+      dump = `pg_dump -h #{uri.hostname} -i -s -x -O #{uri.path.tr("/", "")}`
+      File.open "db/structure.sql", "w" do |file|
+        file.write dump
+      end
+    end
+  end
+
+  task :check_migrations_exist do
+    unless Dir["db/migrate/*.rb"].any?
+      puts "No migrations found"
+      exit 1
+    end
+  end
+
+  # Enhance the migration task provided by ROM
+  desc "Perform migration up to latest migration available"
+  task :migrate => [:check_migrations_exist] do
+    # Once db:migrate finishes, dump the db structure:
+    Rake::Task["db:structure:dump"].execute
+
+    # And print the current migration version:
+    Rake::Task["db:version"].execute
+  end
+
+  desc "Perform rollback to specified target"
+  task :rollback, :target do |t, args|
+    Sequel::Migrator.run(DB, "db/migrate", :target => args[:target].to_i)
+    Rake::Task["db:version"].execute
+  end
+
+  desc "Load seed data into the database"
+  task :seed do
+    seed_data = File.join("db", "seed.rb")
+    load(seed_data) if File.exist?(seed_data)
+  end
+
+  desc "Load a small, representative set of data so that the application can start in a useful state (for development)."
+  task :sample_data do
+    sample_data = File.join("db", "sample_data.rb")
+    load(sample_data) if File.exist?(sample_data)
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/bin/console.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/bin/console.tt
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require "bundler/setup"
 require "dry/web/console"
 require_relative "../component/boot"
 

--- a/lib/dry/web/roda/skeletons/umbrella/bin/console.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/bin/console.tt
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require "dry/web/console"
+require_relative "../component/boot"
+
+Dry::Web::Console.start

--- a/lib/dry/web/roda/skeletons/umbrella/bin/setup
+++ b/lib/dry/web/roda/skeletons/umbrella/bin/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+APP_ROOT = File.expand_path("../../",  __FILE__)
+
+Dir.chdir(APP_ROOT) do
+  # Set up your app for development here
+end

--- a/lib/dry/web/roda/skeletons/umbrella/component/__underscored_app_name__/application.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/component/__underscored_app_name__/application.rb.tt
@@ -1,0 +1,7 @@
+module <%= config[:camel_cased_app_name] %>
+  class Application < Roda
+    route do |r|
+      r.run Main::Application.freeze.app
+    end
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/component/__underscored_app_name__/container.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/component/__underscored_app_name__/container.rb.tt
@@ -1,0 +1,17 @@
+require "dry/web/umbrella"
+require_relative "settings"
+
+module <%= config[:camel_cased_app_name] %>
+  class Container < Dry::Web::Umbrella
+    configure do
+      config.name = :core
+      config.settings_loader = <%= config[:camel_cased_app_name] %>::Settings
+    end
+
+    load_paths! "lib", "component"
+
+    def self.settings
+      config.settings
+    end
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/component/__underscored_app_name__/import.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/component/__underscored_app_name__/import.rb.tt
@@ -1,0 +1,5 @@
+require_relative "container"
+
+module <%= config[:camel_cased_app_name] %>
+  Import = <%= config[:camel_cased_app_name] %>::Container::Inject
+end

--- a/lib/dry/web/roda/skeletons/umbrella/component/__underscored_app_name__/settings.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/component/__underscored_app_name__/settings.rb.tt
@@ -1,0 +1,17 @@
+require "dry/web/settings"
+require "dry-types"
+
+module <%= config[:camel_cased_app_name] %>
+  class Settings < Dry::Web::Settings
+    module Types
+      include Dry::Types.module
+
+      module Required
+        String = Types::Strict::String.constrained(min_size: 1)
+      end
+    end
+
+    setting :database_url, Types::Required::String
+    setting :session_secret, Types::Required::String
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/component/boot.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/component/boot.rb.tt
@@ -1,0 +1,12 @@
+require "byebug" if ENV["RACK_ENV"] == "development"
+require "pry" if ENV["RACK_ENV"] == "development"
+
+require_relative "<%= config[:underscored_app_name] %>/container"
+
+<%= config[:camel_cased_app_name] %>::Container.finalize! do |container|
+end
+
+app_paths = Pathname(__FILE__).dirname.join("../apps").realpath.join("*")
+Dir[app_paths].each { |f| require "#{f}/component/boot" }
+
+require_relative "<%= config[:underscored_app_name] %>/application"

--- a/lib/dry/web/roda/skeletons/umbrella/component/boot/logger.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/component/boot/logger.rb.tt
@@ -1,0 +1,5 @@
+require "logger"
+
+<%= config[:camel_cased_app_name] %>::Container.finalize :logger do |container|
+  container.register "logger", Logger.new(container.root.join("log/#{container.config.env}.log"))
+end

--- a/lib/dry/web/roda/skeletons/umbrella/component/boot/rom.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/component/boot/rom.rb.tt
@@ -1,0 +1,16 @@
+require "sequel"
+require "rom"
+
+Sequel.database_timezone = :utc
+Sequel.application_timezone = :local
+
+<%= config[:camel_cased_app_name] %>::Container.namespace "persistence" do |container|
+  config = ROM::Configuration.new(:sql, container.settings.database_url, extensions: [:error_sql])
+
+  container.register "config", config
+
+  container.finalize :rom do
+    config.auto_registration container.root.join("lib/persistence")
+    container.register "rom", ROM.container(config)
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/config.ru.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/config.ru.tt
@@ -1,0 +1,2 @@
+require_relative "component/boot"
+run <%= config[:camel_cased_app_name] %>::Application.freeze.app

--- a/lib/dry/web/roda/skeletons/umbrella/config/settings.yml.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/config/settings.yml.tt
@@ -1,0 +1,8 @@
+development: &base
+  database_url: 'postgres://localhost/<%= config[:underscored_app_name] %>_development'
+  session_secret: '<%= SecureRandom.hex %>'
+test:
+  <<: *base
+  database_url: 'postgres://localhost/<%= config[:underscored_app_name] %>_test'
+production:
+  <<: *base

--- a/lib/dry/web/roda/skeletons/umbrella/db/sample_data.rb
+++ b/lib/dry/web/roda/skeletons/umbrella/db/sample_data.rb
@@ -1,0 +1,1 @@
+# Build your sample data here

--- a/lib/dry/web/roda/skeletons/umbrella/db/seed.rb
+++ b/lib/dry/web/roda/skeletons/umbrella/db/seed.rb
@@ -1,0 +1,1 @@
+# Build your seed data here

--- a/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/page.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/page.rb.tt
@@ -1,0 +1,48 @@
+module <%= config[:camel_cased_app_name] %>
+  class Page
+    attr_reader :options
+
+    def initialize(options = {})
+      @options = options
+    end
+
+    def view_locals
+      {
+        csrf_token: csrf_token,
+        csrf_tag: csrf_tag,
+      }
+    end
+
+    def csrf_token
+      self[:csrf_token].()
+    end
+
+    def csrf_metatag
+      self[:csrf_metatag].()
+    end
+
+    def csrf_tag
+      self[:csrf_tag].()
+    end
+
+    def flash
+      self[:flash]
+    end
+
+    def flash?
+      %w(notice alert).any? { |type| flash[type] }
+    end
+
+    def with_flash(flash)
+      with(flash: flash)
+    end
+
+    def with(new_options)
+      self.class.new(options.merge(new_options))
+    end
+
+    def [](name)
+      options.fetch(name)
+    end
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/repository.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/repository.rb.tt
@@ -1,0 +1,11 @@
+require "rom-repository"
+require "<%= config[:underscored_app_name] %>/container"
+require "<%= config[:underscored_app_name] %>/import"
+
+<%= config[:camel_cased_app_name] %>::Container.boot! :rom
+
+module <%= config[:camel_cased_app_name] %>
+  class Repository < ROM::Repository::Root
+    include <%= config[:camel_cased_app_name] %>::Import.args["persistence.rom"]
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/test.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/test.rb.tt
@@ -1,0 +1,2 @@
+module <%= config[:camel_cased_app_name] %>
+end

--- a/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/test.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/test.rb.tt
@@ -1,2 +1,0 @@
-module <%= config[:camel_cased_app_name] %>
-end

--- a/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/transactions.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/lib/__underscored_app_name__/transactions.rb.tt
@@ -1,0 +1,33 @@
+require "dry-configurable"
+require "dry-transaction"
+
+module <%= config[:camel_cased_app_name] %>
+  class Transactions
+    extend Dry::Configurable
+
+    attr_reader :options
+
+    setting :container
+    setting :options, {}
+
+    def self.define(&block)
+      yield(new(options))
+    end
+
+    def self.options
+      {container: config.container}.merge(config.options)
+    end
+
+    def initialize(options)
+      @options = options
+    end
+
+    def container
+      options[:container]
+    end
+
+    def define(name, &block)
+      container.register(name, Dry.Transaction(options, &block))
+    end
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/lib/roda_plugins.rb
+++ b/lib/dry/web/roda/skeletons/umbrella/lib/roda_plugins.rb
@@ -1,0 +1,34 @@
+require "roda"
+require "rack/csrf"
+
+class Roda
+  module RodaPlugins
+    module Page
+      module InstanceMethods
+        def current_page
+          page.with_flash(flash)
+        end
+
+        def page
+          self.class["page"].with(
+            csrf_token: -> { Rack::Csrf.token(request.env) },
+            csrf_metatag: -> { Rack::Csrf.metatag(request.env) },
+            csrf_tag: -> { Rack::Csrf.tag(request.env) },
+          )
+        end
+      end
+    end
+
+    module View
+      module RequestMethods
+        def view(name, overrides = {})
+          options = {scope: scope.current_page}.merge(overrides)
+          is to: "#{scope.name}.views.#{name}", call_with: [options]
+        end
+      end
+    end
+
+    register_plugin :page, Page
+    register_plugin :view, View
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/lib/types.rb
+++ b/lib/dry/web/roda/skeletons/umbrella/lib/types.rb
@@ -1,0 +1,5 @@
+require "dry-types"
+
+module Types
+  include Dry::Types.module
+end

--- a/lib/dry/web/roda/skeletons/umbrella/spec/app_helper.rb
+++ b/lib/dry/web/roda/skeletons/umbrella/spec/app_helper.rb
@@ -1,0 +1,35 @@
+require_relative "db_helper"
+
+require "rack/test"
+require "capybara/rspec"
+require "capybara-screenshot/rspec"
+require "capybara/poltergeist"
+
+Dir[SPEC_ROOT.join("support/app/*.rb").to_s].each(&method(:require))
+Dir[SPEC_ROOT.join("shared/app/*.rb").to_s].each(&method(:require))
+
+require SPEC_ROOT.join("../component/boot").realpath
+
+Capybara.app = TestHelpers.app
+Capybara.server_port = 3001
+Capybara.save_and_open_page_path = "#{File.dirname(__FILE__)}/../tmp/capybara-screenshot"
+Capybara.javascript_driver = :poltergeist
+Capybara::Screenshot.prune_strategy = {keep: 10}
+
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(
+    app,
+    js_errors: false,
+    phantomjs_logger: File.open(SPEC_ROOT.join("../log/phantomjs.log"), "w"),
+    phantomjs_options: %w(--load-images=no)
+  )
+end
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods, type: :request
+  config.include Rack::Test::Methods, Capybara::DSL, type: :feature
+
+  config.before :suite do
+    TestHelpers.app.freeze
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/spec/db_helper.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/spec/db_helper.rb.tt
@@ -1,0 +1,24 @@
+require_relative "spec_helper"
+
+<%= config[:camel_cased_app_name] %>::Container.boot! :rom
+
+Dir[SPEC_ROOT.join("support/db/*.rb").to_s].each(&method(:require))
+Dir[SPEC_ROOT.join("shared/db/*.rb").to_s].each(&method(:require))
+
+require "database_cleaner"
+DatabaseCleaner[:sequel, connection: TestHelpers.db_connection].strategy = :truncation
+
+RSpec.configure do |config|
+  config.include TestHelpers
+  config.include TestFactories
+
+  config.before :suite do
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  config.around :each do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+end

--- a/lib/dry/web/roda/skeletons/umbrella/spec/spec_helper.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/spec/spec_helper.rb.tt
@@ -1,0 +1,66 @@
+ENV["RACK_ENV"] = "test"
+
+require "byebug"
+
+SPEC_ROOT = Pathname(__FILE__).dirname
+
+Dir[SPEC_ROOT.join("support/*.rb").to_s].each(&method(:require))
+Dir[SPEC_ROOT.join("shared/*.rb").to_s].each(&method(:require))
+
+require SPEC_ROOT.join("../component/<%= config[:underscored_app_name] %>/container")
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4.
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on a
+    # real object. This is generally recommended, and will default to `true`
+    # in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # These two settings work together to allow you to limit a spec run to
+  # individual examples or groups you care about by tagging them with `:focus`
+  # metadata. When nothing is tagged with `:focus`, all examples get run.
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
+  # Allows RSpec to persist some state between runs in order to support the
+  # `--only-failures` and `--next-failure` CLI options.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # This setting enables warnings. It's recommended, but in some cases may be
+  # too noisy due to issues in dependencies.
+  config.warnings = true
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = "doc"
+  end
+
+  # Print the 10 slowest examples and example groups at the end of the spec
+  # run, to help surface which specs are running particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+end

--- a/lib/dry/web/roda/skeletons/umbrella/spec/support/db/test_factories.rb
+++ b/lib/dry/web/roda/skeletons/umbrella/spec/support/db/test_factories.rb
@@ -1,0 +1,3 @@
+module TestFactories
+  # Helper methods to create test data go here
+end

--- a/lib/dry/web/roda/skeletons/umbrella/spec/support/test_helpers.rb.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/spec/support/test_helpers.rb.tt
@@ -1,0 +1,15 @@
+module TestHelpers
+  module_function
+
+  def app
+    <%= config[:camel_cased_app_name] %>::Application.app
+  end
+
+  def rom
+    <%= config[:camel_cased_app_name] %>::Container["persistence.rom"]
+  end
+
+  def db_connection
+    rom.gateways[:default].connection
+  end
+end


### PR DESCRIPTION
Add some infrastructure for generating code based on skeleton directories. This crawls the skeleton directory structure and uses Thor to copy the files into place with the app-specific names substituted in.

Still to do:
- [x] Provide the complete content for the new project skeleton
- [x] Add a generator for sub-apps
- [x] Work out whether `dry-web-roda` should be the executable we use to access these generators or whether this should be wrapped up and accessible from a single `dry-web` executable.

Long term, the idea will be to have each dry-web "integration" gem (e.g. dry-web-roda, dry-web-hanami) provide their own generators, each providing a fairly reasonable new project starting point. People who want something custom can build their own skeletons/generators (potentially using this `Generate` class, or tools of their own choosing).

This look OK to you @solnic, @AMHOL, @gotar? If so, I reckon I'll be able to finish this off just in time for RedDotRubyConf :)
