### PR TITLE
Replace shotgun with notgun

### DIFF
--- a/lib/dry/web/roda/skeletons/umbrella/Gemfile
+++ b/lib/dry/web/roda/skeletons/umbrella/Gemfile
@@ -7,7 +7,9 @@ gem "dry-web", ">= 0.4.0"
 gem "dry-web-roda", ">= 0.3.0"
 gem "puma"
 gem "rack_csrf"
-gem "shotgun"
+
+gem "rack", ">= 2.0"
+gem "notgun"
 
 # Database persistence
 gem "pg"

--- a/lib/dry/web/roda/skeletons/umbrella/README.md.tt
+++ b/lib/dry/web/roda/skeletons/umbrella/README.md.tt
@@ -8,5 +8,5 @@ Welcome! You’ve generated an app using dry-web-roda.
 1. Review `config/settings.yml` (and make a copy at `config/settings.example.yml` if you want to keep example settings checked in)
 1. Create a `<%= config[:underscored_app_name] %>_development` database
 1. Add your own steps to `bin/setup`
-1. Run the app with `bundle exec shotgun -p 3000 -o 0.0.0.0 config.ru`
+1. Run the app with `bundle exec notgun -p 3000 -o 0.0.0.0 config.ru`
 1. Initialize git with `git init` and make your initial commit


### PR DESCRIPTION
Shotgun doesn't work with rack >= 2.0. Notgun is shotgun fork which was fixed for rack >= 2.0.

I added additional empty line because rack and notgun aren't web framework part in my opinion. Please let me know if you don't agree with it and I will remove this empty line.
