### PR TITLE
Use released ROM gems

### DIFF
--- a/lib/dry/web/roda/skeletons/umbrella/Gemfile
+++ b/lib/dry/web/roda/skeletons/umbrella/Gemfile
@@ -11,11 +11,8 @@ gem "shotgun"
 
 # Database persistence
 gem "pg"
-gem "rom",            github: "rom-rb/rom"
-gem "rom-mapper",     github: "rom-rb/rom-mapper"
-gem "rom-repository", github: "rom-rb/rom-repository"
-gem "rom-sql",        github: "rom-rb/rom-sql"
-gem "rom-support",    github: "rom-rb/rom-support"
+gem "rom-repository"
+gem "rom-sql"
 
 # Application dependencies
 gem "dry-result_matcher"


### PR DESCRIPTION
ROM 2.0 was released on July 27, 2016. I think it is better to use relased version in default skeleton instead of unreleased version.

I have compared dependency graph before:
![gem_graph-before](https://cloud.githubusercontent.com/assets/945115/17717324/b0cb156a-640d-11e6-9ea5-d95f3d9906c7.png)
and after:
![gem_graph-after](https://cloud.githubusercontent.com/assets/945115/17717327/b6710bdc-640d-11e6-8a44-e1fe86b5bfdb.png)
