### PR TITLE
Use container from config to fetch rack-monitor

### DIFF
--- a/lib/dry/web/roda/application.rb
+++ b/lib/dry/web/roda/application.rb
@@ -16,9 +16,9 @@ module Dry
         plugin :error_handler
 
         def self.configure(&block)
-          container = super
-          use(container[:rack_monitor])
-          container
+          super.tap do
+            use(config.container[:rack_monitor])
+          end
         end
 
         def self.resolve(name)


### PR DESCRIPTION
We can't rely on the return value from `.configure` here, since it  returns the value of the last applied setting (which won't always be our container).

This fixes the bug that will arise if a Dry::Web::Roda::Application is configured and the container is not the last setting applied.