### PR TITLE
Support apps with hypens in their name (i.e. dry-test)

### DIFF
--- a/lib/dry/web/roda/generators/flat_project.rb
+++ b/lib/dry/web/roda/generators/flat_project.rb
@@ -19,9 +19,10 @@ module Dry
           private
 
           def prepare_scope(target_dir)
+            underscored_app_name = Inflecto.underscore(target_dir)
             {
-              underscored_app_name: Inflecto.underscore(target_dir),
-              camel_cased_app_name: Inflecto.camelize(target_dir)
+              underscored_app_name: underscored_app_name,
+              camel_cased_app_name: Inflecto.camelize(underscored_app_name)
             }
           end
         end

--- a/spec/integration/new_app_spec.rb
+++ b/spec/integration/new_app_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe "new app", type: :cli do
       end
     end
   end
+
+  describe "flat project with hyphen separated name" do
+    it "boots and displays a welcome page" do
+      with_project "dry-test", arch: "flat" do
+        run_app do |app|
+          expect(app.get("/")).to eq "<html><body><h1>Welcome to dry-web-roda!</h1></body></html>"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
I tried generating a new app today using this command:

```
dry-web-roda dry-test
```

The app generated fine, but when I went to run this app with `rackup`, I saw this error:

```
/Users/ryanbigg/code/playground/dry-test/system/boot.rb:4:in `require_relative': /Users/ryanbigg/code/playground/dry-test/system/dry_test/container.rb:4: syntax error, unexpected '-' (SyntaxError)
module Dry-test
```

It appears that the module name for the application here is not correctly constantized. I couldn't find one `Inflecto` method which handles this case, so I'm using a combo of underscoreize + camelize methods to produce the right output `DryTest`.