### PR TITLE
Require securerandom for flat arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ Gemfile.lock
 
 .byebug_history
 /vendor/cache/
+
+.idea

--- a/lib/dry/web/roda/generators/flat_project.rb
+++ b/lib/dry/web/roda/generators/flat_project.rb
@@ -1,4 +1,5 @@
 require "inflecto"
+require "securerandom"
 require "dry/web/roda/generate"
 
 module Dry


### PR DESCRIPTION
Stumbled upon this when I've tried to create a new project with flat arch.

I don't know of a good way to test this unfortunately from the integration tests.