### PR TITLE
Add custom inflections for generators

### DIFF
--- a/lib/dry/web/roda/generators/flat_project.rb
+++ b/lib/dry/web/roda/generators/flat_project.rb
@@ -1,6 +1,6 @@
-require "inflecto"
 require "securerandom"
 require "dry/web/roda/generate"
+require "dry/web/roda/generators/inflections"
 
 module Dry
   module Web
@@ -21,8 +21,8 @@ module Dry
 
           def prepare_scope(target_dir)
             {
-              underscored_app_name: Inflecto.underscore(target_dir),
-              camel_cased_app_name: Inflecto.camelize(target_dir)
+              underscored_app_name: Inflections.underscored_name(target_dir),
+              camel_cased_app_name: Inflections.camel_cased_name(target_dir)
             }
           end
         end

--- a/lib/dry/web/roda/generators/inflections.rb
+++ b/lib/dry/web/roda/generators/inflections.rb
@@ -1,0 +1,21 @@
+require "inflecto"
+
+module Dry
+  module Web
+    module Roda
+      module Generators
+        module Inflections
+          module_function
+
+          def underscored_name(name)
+            Inflecto.underscore(name)
+          end
+
+          def camel_cased_name(name)
+            Inflecto.camelize(underscored_name(name))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/web/roda/generators/sub_app.rb
+++ b/lib/dry/web/roda/generators/sub_app.rb
@@ -1,5 +1,5 @@
-require "inflecto"
 require "dry/web/roda/generate"
+require "dry/web/roda/generators/inflections"
 
 module Dry
   module Web
@@ -23,10 +23,10 @@ module Dry
 
           def prepare_scope(target_dir, umbrella_name)
             {
-              underscored_app_name: Inflecto.underscore(target_dir),
-              camel_cased_app_name: Inflecto.camelize(target_dir),
-              underscored_umbrella_name: Inflecto.underscore(umbrella_name),
-              camel_cased_umbrella_name: Inflecto.camelize(umbrella_name),
+              underscored_app_name: Inflections.underscored_name(target_dir),
+              camel_cased_app_name: Inflections.camel_cased_name(target_dir),
+              underscored_umbrella_name: Inflections.underscored_name(umbrella_name),
+              camel_cased_umbrella_name: Inflections.camel_cased_name(umbrella_name),
             }
           end
         end

--- a/lib/dry/web/roda/generators/umbrella_project.rb
+++ b/lib/dry/web/roda/generators/umbrella_project.rb
@@ -1,6 +1,6 @@
-require "inflecto"
 require "securerandom"
 require "dry/web/roda/generate"
+require "dry/web/roda/generators/inflections"
 require "dry/web/roda/generators/sub_app"
 
 module Dry
@@ -27,8 +27,8 @@ module Dry
 
           def prepare_scope(target_dir)
             {
-              underscored_app_name: Inflecto.underscore(target_dir),
-              camel_cased_app_name: Inflecto.camelize(target_dir)
+              underscored_app_name: Inflections.underscored_name(target_dir),
+              camel_cased_app_name: Inflections.camel_cased_name(target_dir)
             }
           end
         end

--- a/spec/unit/generators/inflections_spec.rb
+++ b/spec/unit/generators/inflections_spec.rb
@@ -1,0 +1,33 @@
+require "dry/web/roda/generators/inflections"
+
+RSpec.describe Dry::Web::Roda::Generators::Inflections do
+  subject(:inflections) { described_class }
+
+  describe ".underscored_name" do
+    it "leaves an already underscored name" do
+      expect(inflections.underscored_name("my_app")).to eq "my_app"
+    end
+
+    it "leaves a name without any sort of delimiters" do
+      expect(inflections.underscored_name("myapp")).to eq "myapp"
+    end
+
+    it "converts a dashed name" do
+      expect(inflections.underscored_name("my-app")).to eq "my_app"
+    end
+  end
+
+  describe ".camel_cased_name" do
+    it "leaves an already camel cased name" do
+      expect(inflections.camel_cased_name("MyApp")).to eq "MyApp"
+    end
+
+    it "converts a dashed name" do
+      expect(inflections.camel_cased_name("my-app")).to eq "MyApp"
+    end
+
+    it "converts an underscored name" do
+      expect(inflections.camel_cased_name("my_app")).to eq "MyApp"
+    end
+  end
+end


### PR DESCRIPTION
Encapsulate some common inflections for generated apps in our own module, which will help ensure consistency across the generators.

This also includes a fix to properly handle dashed app names (e.g. “my-app”) when generating new projects. Resolves #33.