### PR TITLE
Use full url as dbname to include credentials in pg_dump

### DIFF
--- a/lib/dry/web/roda/templates/Rakefile.tt
+++ b/lib/dry/web/roda/templates/Rakefile.tt
@@ -34,10 +34,7 @@ namespace :db do
   namespace :structure do
     desc "Dump database structure to db/structure.sql"
     task :dump do
-      require "uri"
-      uri = URI(DB.url)
-
-      dump = `pg_dump -h #{uri.hostname} -s -x -O #{uri.path.tr("/", "")}`
+      dump = `pg_dump -s -x -O #{DB.url}`
       File.open "db/structure.sql", "w" do |file|
         file.write dump
       end


### PR DESCRIPTION
Hi guys,

I'm use to use user and password for postgres setup and got stuck to dump `db/structure.sql`.

It works as is but it is not the best solution in my opinion; what do you think about adding `database_user` and `database_password` settings into the application's container?