### PR TITLE
Reorganize views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'byebug', platform: :mri
 gem 'codeclimate-test-reporter', platform: :rbx
 
 # Generated application dependencies
+gem "dry-system", ">= 0.7.0"
 gem "dry-web", ">= 0.6.0"
 gem "puma"
 gem "rack_csrf"

--- a/lib/dry/web/roda/generators/flat_project.rb
+++ b/lib/dry/web/roda/generators/flat_project.rb
@@ -47,6 +47,8 @@ module Dry
           end
 
           def add_lib
+            add_template('view_context.rb.tt', "lib/#{underscored_project_name}/view/context.rb")
+            add_template('view_controller.rb.tt', "lib/#{underscored_project_name}/view/controller.rb")
             add_template('welcome.rb.tt', "lib/#{underscored_project_name}/views/welcome.rb")
             add_template('.keep', "lib/#{underscored_project_name}/.keep")
             add_template('.keep', 'lib/persistance/commands/.keep')
@@ -72,7 +74,7 @@ module Dry
           end
 
           def add_system_app_folder
-            %w(application container import repository settings transactions view_context view_controller).each do |file|
+            %w(application container import repository settings transactions).each do |file|
               add_template("#{file}.rb.tt", "system/#{underscored_project_name}/#{file}.rb")
             end
           end

--- a/lib/dry/web/roda/generators/flat_project.rb
+++ b/lib/dry/web/roda/generators/flat_project.rb
@@ -80,7 +80,7 @@ module Dry
           end
 
           def add_system_boot
-            %w(monitor rom view).each do |file|
+            %w(monitor rom).each do |file|
               add_template("#{file}.rb.tt", "system/boot/#{file}.rb")
             end
             add_template('boot.rb.tt', 'system/boot.rb')

--- a/lib/dry/web/roda/generators/sub_app.rb
+++ b/lib/dry/web/roda/generators/sub_app.rb
@@ -23,12 +23,14 @@ module Dry
           end
 
           def add_lib
+            add_template('subapp/view_context.rb.tt', "lib/#{underscored_project_name}/view/context.rb")
+            add_template('subapp/view_controller.rb.tt', "lib/#{underscored_project_name}/view/controller.rb")
             add_template('welcome.rb.tt', "lib/#{underscored_project_name}/views/welcome.rb")
             add_template('.keep', "lib/#{underscored_project_name}/.keep")
           end
 
           def add_system
-            %w(application container transactions view_context view_controller).each do |file|
+            %w(application container transactions).each do |file|
               add_template("subapp/#{file}.rb.tt", "system/#{underscored_project_name}/#{file}.rb")
             end
             add_template('import.rb.tt', "system/#{underscored_project_name}/import.rb")

--- a/lib/dry/web/roda/generators/sub_app.rb
+++ b/lib/dry/web/roda/generators/sub_app.rb
@@ -34,7 +34,6 @@ module Dry
               add_template("subapp/#{file}.rb.tt", "system/#{underscored_project_name}/#{file}.rb")
             end
             add_template('import.rb.tt', "system/#{underscored_project_name}/import.rb")
-            add_template('subapp/view.rb.tt', 'system/boot/view.rb')
             add_template('subapp/boot.rb.tt', 'system/boot.rb')
           end
 

--- a/lib/dry/web/roda/templates/Gemfile
+++ b/lib/dry/web/roda/templates/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rake"
 
 # Web framework
+gem "dry-system", ">= 0.7.0"
 gem "dry-web", ">= 0.6.0"
 gem "dry-web-roda", ">= 0.6.0"
 gem "puma"

--- a/lib/dry/web/roda/templates/subapp/view.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/view.rb.tt
@@ -1,3 +1,0 @@
-require "<%= config[:underscored_project_name] %>/view_context"
-
-<%= config[:camel_cased_app_name] %>::Container.register "view_context", <%= config[:camel_cased_app_name] %>::ViewContext.new

--- a/lib/dry/web/roda/templates/subapp/view_context.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/view_context.rb.tt
@@ -1,6 +1,8 @@
-require "<%= config[:underscored_umbrella_name] %>/view_context"
+require "<%= config[:underscored_umbrella_name] %>/view/context"
 
 module <%= config[:camel_cased_app_name] %>
-  class ViewContext < <%= config[:camel_cased_umbrella_name] %>::ViewContext
+  module View
+    class Context < <%= config[:camel_cased_umbrella_name] %>::View::Context
+    end
   end
 end

--- a/lib/dry/web/roda/templates/subapp/view_controller.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/view_controller.rb.tt
@@ -9,7 +9,7 @@ module <%= config[:camel_cased_app_name] %>
     class Controller < Dry::View::Controller
       configure do |config|
         config.paths = [Container.root.join("web/templates")]
-        config.context = Container["view_context"]
+        config.context = Container["view.context"]
         config.layout = "application"
       end
     end

--- a/lib/dry/web/roda/templates/subapp/view_controller.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/view_controller.rb.tt
@@ -1,13 +1,16 @@
+# auto_register: false
+
 require "slim"
 require "dry-view"
 require "<%= config[:underscored_project_name] %>/container"
 
 module <%= config[:camel_cased_app_name] %>
-  class ViewController < Dry::View::Controller
-    configure do |config|
-      config.paths = [Container.root.join("web/templates")]
-      config.context = Container["view_context"]
-      config.layout = "application"
+  module View
+    class Controller < Dry::View::Controller
+      configure do |config|
+        config.paths = [Container.root.join("web/templates")]
+        config.context = Container["view_context"]
+        config.layout = "application"
+      end
     end
   end
-end

--- a/lib/dry/web/roda/templates/view.rb.tt
+++ b/lib/dry/web/roda/templates/view.rb.tt
@@ -1,3 +1,0 @@
-require "<%= config[:underscored_project_name] %>/view_context"
-
-<%= config[:camel_cased_app_name] %>::Container.register "view_context", <%= config[:camel_cased_app_name] %>::ViewContext.new

--- a/lib/dry/web/roda/templates/view_context.rb.tt
+++ b/lib/dry/web/roda/templates/view_context.rb.tt
@@ -1,39 +1,43 @@
+# auto_register: false
+
 module <%= config[:camel_cased_app_name] %>
-  class ViewContext
-    attr_reader :attrs
+  module View
+    class Context
+      attr_reader :attrs
 
-    def initialize(attrs = {})
-      @attrs = attrs
-    end
+      def initialize(attrs = {})
+        @attrs = attrs
+      end
 
-    def csrf_token
-      self[:csrf_token]
-    end
+      def csrf_token
+        self[:csrf_token]
+      end
 
-    def csrf_metatag
-      self[:csrf_metatag]
-    end
+      def csrf_metatag
+        self[:csrf_metatag]
+      end
 
-    def csrf_tag
-      self[:csrf_tag]
-    end
+      def csrf_tag
+        self[:csrf_tag]
+      end
 
-    def flash
-      self[:flash]
-    end
+      def flash
+        self[:flash]
+      end
 
-    def flash?
-      %i[notice alert].any? { |type| flash[type] }
-    end
+      def flash?
+        %i[notice alert].any? { |type| flash[type] }
+      end
 
-    def with(new_attrs)
-      self.class.new(attrs.merge(new_attrs))
-    end
+      def with(new_attrs)
+        self.class.new(attrs.merge(new_attrs))
+      end
 
-    private
+      private
 
-    def [](name)
-      attrs.fetch(name)
+      def [](name)
+        attrs.fetch(name)
+      end
     end
   end
 end

--- a/lib/dry/web/roda/templates/view_controller.rb.tt
+++ b/lib/dry/web/roda/templates/view_controller.rb.tt
@@ -9,7 +9,7 @@ module <%= config[:camel_cased_app_name] %>
     class Controller < Dry::View::Controller
       configure do |config|
         config.paths = [Container.root.join("web/templates")]
-        config.context = Container["view_context"]
+        config.context = Container["view.context"]
         config.layout = "application"
       end
     end

--- a/lib/dry/web/roda/templates/view_controller.rb.tt
+++ b/lib/dry/web/roda/templates/view_controller.rb.tt
@@ -1,13 +1,17 @@
+# auto_register: false
+
 require "slim"
 require "dry-view"
 require "<%= config[:underscored_project_name] %>/container"
 
 module <%= config[:camel_cased_app_name] %>
-  class ViewController < Dry::View::Controller
-    configure do |config|
-      config.paths = [Container.root.join("web/templates")]
-      config.context = Container["view_context"]
-      config.layout = "application"
+  module View
+    class Controller < Dry::View::Controller
+      configure do |config|
+        config.paths = [Container.root.join("web/templates")]
+        config.context = Container["view_context"]
+        config.layout = "application"
+      end
     end
   end
 end

--- a/lib/dry/web/roda/templates/welcome.rb.tt
+++ b/lib/dry/web/roda/templates/welcome.rb.tt
@@ -1,8 +1,8 @@
-require "<%= config[:underscored_project_name] %>/view_controller"
+require "<%= config[:underscored_project_name] %>/view/controller"
 
 module <%= config[:camel_cased_app_name] %>
   module Views
-    class Welcome < <%= config[:camel_cased_app_name] %>::ViewController
+    class Welcome < <%= config[:camel_cased_app_name] %>::View::Controller
       configure do |config|
         config.template = "welcome"
       end

--- a/lib/roda/plugins/dry_view.rb
+++ b/lib/roda/plugins/dry_view.rb
@@ -9,7 +9,7 @@ class Roda
 
       module InstanceMethods
         def view_context
-          self.class["view_context"].with(view_context_options)
+          self.class["view.context"].with(view_context_options)
         end
 
         def view_context_options

--- a/spec/support/project.rb
+++ b/spec/support/project.rb
@@ -16,7 +16,7 @@ module RSpec
           create_project name, args
 
           within_project_directory(name) do
-            setup_gemfile
+            setup_gemfile gems: ["'dry-web-roda', path: '#{root}'"], exclude_gems: ['dry-web-roda']
             bundle_install
             yield
           end


### PR DESCRIPTION
Some small adjustments in anticipation of the auto-registration configuration flexibility coming soon in dry-system:

- Move view classes out of system dirs and into the main lib dirs
- Put view classes into their own `View` module namespace
- Disable auto-registration of View::Controller classes via magic comments
- Remove bootable dep for view given that View::Context will be picked up by auto-registrar now
- Refer to view context registration as "view.context"  instead of "view_context", to match new naming

Apart from tidying up the views, the idea here is to reduce the amount of application code we keep in the system dirs – these should be reserved for low-level infrastructure only.

This should not be released until the next release of dry-system. Since this is also a breaking change (the Roda view plugin is now looking for a different container registration), it'd probably be worth seeing what else we can tidy in dry-web-roda at the same time.