### PR TITLE
Generate a shared Operation class for new projects

### DIFF
--- a/lib/dry/web/roda/generators/flat_project.rb
+++ b/lib/dry/web/roda/generators/flat_project.rb
@@ -46,14 +46,14 @@ module Dry
           end
 
           def add_lib
+            add_template('types.rb', 'lib/types.rb')
             add_template('operation.rb.tt', "lib/#{underscored_project_name}/operation.rb")
+            add_template('repository.rb.tt', "lib/#{underscored_project_name}/repository.rb")
+            add_template('.keep', 'lib/persistance/relations/.keep')
+            add_template('.keep', 'lib/persistance/commands/.keep')
             add_template('view_context.rb.tt', "lib/#{underscored_project_name}/view/context.rb")
             add_template('view_controller.rb.tt', "lib/#{underscored_project_name}/view/controller.rb")
             add_template('welcome.rb.tt', "lib/#{underscored_project_name}/views/welcome.rb")
-            add_template('.keep', "lib/#{underscored_project_name}/.keep")
-            add_template('.keep', 'lib/persistance/commands/.keep')
-            add_template('.keep', 'lib/persistance/relations/.keep')
-            add_template('types.rb', 'lib/types.rb')
           end
 
           def add_log
@@ -69,12 +69,12 @@ module Dry
           end
 
           def add_system
-            add_system_app_folder
+            add_system_lib
             add_system_boot
           end
 
-          def add_system_app_folder
-            %w(application container import repository settings).each do |file|
+          def add_system_lib
+            %w(application container import settings).each do |file|
               add_template("#{file}.rb.tt", "system/#{underscored_project_name}/#{file}.rb")
             end
           end

--- a/lib/dry/web/roda/generators/flat_project.rb
+++ b/lib/dry/web/roda/generators/flat_project.rb
@@ -46,6 +46,7 @@ module Dry
           end
 
           def add_lib
+            add_template('operation.rb.tt', "lib/#{underscored_project_name}/operation.rb")
             add_template('view_context.rb.tt', "lib/#{underscored_project_name}/view/context.rb")
             add_template('view_controller.rb.tt', "lib/#{underscored_project_name}/view/controller.rb")
             add_template('welcome.rb.tt', "lib/#{underscored_project_name}/views/welcome.rb")

--- a/lib/dry/web/roda/generators/umbrella_project.rb
+++ b/lib/dry/web/roda/generators/umbrella_project.rb
@@ -7,13 +7,11 @@ module Dry
     module Roda
       module Generators
         class UmbrellaProject < FlatProject
-
           def post_process_callback
             Dir.chdir(target_dir) do
               Generators::SubApp.new("main", umbrella: target_dir).call
             end
           end
-
         end
       end
     end

--- a/lib/dry/web/roda/templates/operation.rb.tt
+++ b/lib/dry/web/roda/templates/operation.rb.tt
@@ -1,0 +1,9 @@
+# auto_register: false
+
+require "dry/transaction/operation"
+
+module <%= config[:camel_cased_app_name] %>
+  class Operation
+    include Dry::Transaction::Operation
+  end
+end


### PR DESCRIPTION
This includes Dry::Transaction::Operation to give the class access to Right/Left monad builders and also a dry-matcher block API for `#call`