### PR TITLE
Fix operation template to work with Dry::Matcher

### DIFF
--- a/lib/dry/web/roda/templates/.gitignore
+++ b/lib/dry/web/roda/templates/.gitignore
@@ -6,3 +6,6 @@
 
 # Logs
 /log/*.log
+
+# Temp files
+tmp/*

--- a/lib/dry/web/roda/templates/operation.rb.tt
+++ b/lib/dry/web/roda/templates/operation.rb.tt
@@ -4,6 +4,8 @@ require "dry/transaction/operation"
 
 module <%= config[:camel_cased_app_name] %>
   class Operation
-    include Dry::Transaction::Operation
+    def self.inherited(subclass)
+      subclass.include Dry::Transaction::Operation
+    end
   end
 end

--- a/lib/dry/web/roda/templates/spec/spec_helper.rb.tt
+++ b/lib/dry/web/roda/templates/spec/spec_helper.rb.tt
@@ -1,6 +1,6 @@
 ENV["RACK_ENV"] = "test"
 
-require "byebug"
+require "pry-byebug"
 
 SPEC_ROOT = Pathname(__FILE__).dirname
 

--- a/lib/dry/web/roda/templates/spec/web_spec_helper.rb
+++ b/lib/dry/web/roda/templates/spec/web_spec_helper.rb
@@ -12,7 +12,7 @@ require SPEC_ROOT.join("../system/boot").realpath
 
 Capybara.app = Test::WebHelpers.app
 Capybara.server_port = 3001
-Capybara.save_and_open_page_path = "#{File.dirname(__FILE__)}/../tmp/capybara-screenshot"
+Capybara.save_path = "#{File.dirname(__FILE__)}/../tmp/capybara-screenshot"
 Capybara.javascript_driver = :poltergeist
 Capybara::Screenshot.prune_strategy = {keep: 10}
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require "byebug"
+require "pry-byebug"
 
 SPEC_ROOT = Pathname(__dir__)
 TEST_APP_NAME = "test_app".freeze


### PR DESCRIPTION
* Allow operation subclass prepend matcher module #call
* Gitignore tmp dir
* Require pry-byebug by default in template spec helper and current gem
* spec helper
* Update deprecated call to Capybara#save_path