### PR TITLE
Tweak rack monitor setup

### DIFF
--- a/lib/dry/web/roda/templates/subapp/application.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/application.rb.tt
@@ -24,11 +24,6 @@ module <%= config[:camel_cased_app_name] %>
       end
     end
 
-    error do |e|
-      self.class[:rack_monitor].instrument(:error, exception: e)
-      raise e
-    end
-
     load_routes!
   end
 end

--- a/lib/dry/web/roda/templates/subapp/container.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/container.rb.tt
@@ -6,8 +6,6 @@ module <%= config[:camel_cased_app_name] %>
     require root.join("system/<%= config[:underscored_umbrella_name] %>/container")
     import core: <%= config[:camel_cased_umbrella_name] %>::Container
 
-    register :rack_monitor, <%= config[:camel_cased_umbrella_name] %>::Container[:rack_monitor]
-
     configure do |config|
       config.root = Pathname(__FILE__).join("../..").realpath.dirname.freeze
       config.logger = <%= config[:camel_cased_umbrella_name] %>::Container[:logger]


### PR DESCRIPTION
Don’t share core container’s rack monitor inside sub-app containers: because of the way the umbrella Roda application dispatches requests to the sub-applications, this results in requests being logged twice.

Along with this, remove error handling from generated sub-applications, since without the shared rack_monitor registration, this may not log errors in the expected places. This block isn't strictly necessary in sub-apps anyway, since it's handled in the top-level umbrella app.