### PR TITLE
Fix Dry::System::InvalidComponentError on rake task(s) (db:create)

### DIFF
--- a/lib/dry/web/roda/templates/Rakefile.tt
+++ b/lib/dry/web/roda/templates/Rakefile.tt
@@ -11,6 +11,8 @@ begin
 rescue LoadError
 end
 
+<%= config[:camel_cased_app_name] %>::Container.finalize!
+
 def db
   <%= config[:camel_cased_app_name] %>::Container["persistence.db"]
 end


### PR DESCRIPTION
This issue affects `rake` and might mask another error I'm investigating that also affects `rake` under the same conditions after the fix below.

*Steps to reproduce*

1. Create a project via

```
gem install dry-web-roda -v 0.7.5
dry-web-roda new viableproduct
cd viableproduct
```

2. Ensure the project-specific development and test databases do not exist in Postgres yet.

3. Execute `rake db:create`

This yields the following error:
```
Dry::System::InvalidComponentError: Tried to create an invalid "settings" component - namespace +viableproduct+ not found in path
```

*A fix*

Finalizing the container in the `Rakefile` did the trick, but this might not be how/where you want to do this.  I'm still getting familiar with the ecosystem and its norms.  Thanks for all your efforts!

*Note on tests*

I didn't see any existing coverage for this, and I'm sorry I didn't include any.  That's something I want to help with in some future contributions.