### PR TITLE
Rename Application classes to Web

### DIFF
--- a/lib/dry/web/roda/generators/flat_project.rb
+++ b/lib/dry/web/roda/generators/flat_project.rb
@@ -19,7 +19,7 @@ module Dry
           end
 
           def add_application
-            add_template("flat_project/application.rb.tt", "system/#{underscored_project_name}/application.rb")
+            add_template("flat_project/web.rb.tt", "system/#{underscored_project_name}/web.rb")
           end
 
           def add_views

--- a/lib/dry/web/roda/generators/sub_app.rb
+++ b/lib/dry/web/roda/generators/sub_app.rb
@@ -40,7 +40,7 @@ module Dry
           end
 
           def add_system
-            add_template('subapp/application.rb.tt', "#{system_lib_path}/application.rb")
+            add_template('subapp/web.rb.tt', "#{system_lib_path}/web.rb")
             add_template('subapp/container.rb.tt', "#{system_lib_path}/container.rb")
             add_template('subapp/import.rb.tt', "#{system_lib_path}/import.rb")
             add_template('subapp/boot.rb.tt', 'system/boot.rb')

--- a/lib/dry/web/roda/generators/umbrella_project.rb
+++ b/lib/dry/web/roda/generators/umbrella_project.rb
@@ -14,7 +14,7 @@ module Dry
           end
 
           def add_application
-            add_template("umbrella_project/application.rb.tt", "system/#{underscored_project_name}/application.rb")
+            add_template("umbrella_project/web.rb.tt", "system/#{underscored_project_name}/web.rb")
           end
 
           def post_process_callback

--- a/lib/dry/web/roda/templates/config.ru.tt
+++ b/lib/dry/web/roda/templates/config.ru.tt
@@ -1,2 +1,2 @@
 require_relative "system/boot"
-run <%= config[:camel_cased_app_name] %>::Application.freeze.app
+run <%= config[:camel_cased_app_name] %>::Web.freeze.app

--- a/lib/dry/web/roda/templates/example_routes.rb.tt
+++ b/lib/dry/web/roda/templates/example_routes.rb.tt
@@ -1,6 +1,6 @@
 # Define your routes like this:
 #
-# class <%= config[:camel_cased_app_name] %>::Application
+# class <%= config[:camel_cased_app_name] %>::Web
 #   route "example" do |r|
 #     # Routes go here
 #   end

--- a/lib/dry/web/roda/templates/flat_project/boot.rb.tt
+++ b/lib/dry/web/roda/templates/flat_project/boot.rb.tt
@@ -7,4 +7,4 @@ require_relative "<%= config[:underscored_project_name] %>/container"
 
 <%= config[:camel_cased_app_name] %>::Container.finalize!
 
-require "<%= config[:underscored_project_name] %>/application"
+require "<%= config[:underscored_project_name] %>/web"

--- a/lib/dry/web/roda/templates/flat_project/web.rb.tt
+++ b/lib/dry/web/roda/templates/flat_project/web.rb.tt
@@ -2,7 +2,7 @@ require "dry/web/roda/application"
 require_relative "container"
 
 module <%= config[:camel_cased_app_name] %>
-  class Application < Dry::Web::Roda::Application
+  class Web < Dry::Web::Roda::Application
     configure do |config|
       config.container = Container
       config.routes = "web/routes".freeze

--- a/lib/dry/web/roda/templates/spec/support/web/helpers.rb.tt
+++ b/lib/dry/web/roda/templates/spec/support/web/helpers.rb.tt
@@ -3,7 +3,7 @@ module Test
     module_function
 
     def app
-      <%= config[:camel_cased_app_name] %>::Application.app
+      <%= config[:camel_cased_app_name] %>::Web.app
     end
   end
 end

--- a/lib/dry/web/roda/templates/subapp/boot.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/boot.rb.tt
@@ -2,4 +2,4 @@ require_relative "<%= config[:underscored_umbrella_name] %>/<%= config[:undersco
 
 <%= config[:camel_cased_umbrella_name] %>::<%= config[:camel_cased_app_name] %>::Container.finalize!
 
-require "<%= config[:underscored_umbrella_name] %>/<%= config[:underscored_project_name] %>/application"
+require "<%= config[:underscored_umbrella_name] %>/<%= config[:underscored_project_name] %>/web"

--- a/lib/dry/web/roda/templates/subapp/example_routes.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/example_routes.rb.tt
@@ -1,6 +1,6 @@
 # Define your routes like this:
 #
-# class <%= config[:camel_cased_umbrella_name] %>::<%= config[:camel_cased_app_name] %>::Application
+# class <%= config[:camel_cased_umbrella_name] %>::<%= config[:camel_cased_app_name] %>::Web
 #   route "example" do |r|
 #     # Routes go here
 #   end

--- a/lib/dry/web/roda/templates/subapp/web.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/web.rb.tt
@@ -3,7 +3,7 @@ require_relative "container"
 
 module <%= config[:camel_cased_umbrella_name] %>
   module <%= config[:camel_cased_app_name] %>
-    class Application < Dry::Web::Roda::Application
+    class Web < Dry::Web::Roda::Application
       configure do |config|
         config.container = Container
         config.routes = "web/routes".freeze

--- a/lib/dry/web/roda/templates/umbrella_project/boot.rb.tt
+++ b/lib/dry/web/roda/templates/umbrella_project/boot.rb.tt
@@ -13,4 +13,4 @@ Dir[app_paths].each do |f|
   require "#{f}/system/boot"
 end
 
-require "<%= config[:underscored_project_name] %>/application"
+require "<%= config[:underscored_project_name] %>/web"

--- a/lib/dry/web/roda/templates/umbrella_project/web.rb.tt
+++ b/lib/dry/web/roda/templates/umbrella_project/web.rb.tt
@@ -2,13 +2,13 @@ require "dry/web/roda/application"
 require_relative "container"
 
 module <%= config[:camel_cased_app_name] %>
-  class Application < Dry::Web::Roda::Application
+  class Web < Dry::Web::Roda::Application
     configure do |config|
       config.container = Container
     end
 
     route do |r|
-      r.run <%= config[:camel_cased_app_name] %>::Main::Application.freeze.app
+      r.run <%= config[:camel_cased_app_name] %>::Main::Web.freeze.app
     end
 
     error do |e|


### PR DESCRIPTION
One of the big ideas we’re promoting with this application structure is that the _web interface is not your app._ Having the web interface class named `Application` kind of interfered with that message. `Web` is a much clearer demonstration of its purpose: it’s just one of (potentially many) interfaces to your core app.