### PR TITLE
Reduce default roda plugin dependencies

### DIFF
--- a/lib/dry/web/roda/application.rb
+++ b/lib/dry/web/roda/application.rb
@@ -11,7 +11,6 @@ module Dry
         setting :container, reader: true
         setting :routes
 
-        plugin :multi_route
         plugin :flow
         plugin :error_handler
 

--- a/lib/dry/web/roda/application.rb
+++ b/lib/dry/web/roda/application.rb
@@ -12,7 +12,6 @@ module Dry
         setting :routes
 
         plugin :flow
-        plugin :error_handler
 
         def self.configure(&block)
           super.tap do

--- a/lib/dry/web/roda/templates/flat_project/web.rb.tt
+++ b/lib/dry/web/roda/templates/flat_project/web.rb.tt
@@ -13,9 +13,9 @@ module <%= config[:camel_cased_app_name] %>
     use Rack::Session::Cookie, key: "<%= config[:underscored_project_name] %>.session", secret: self["settings"].session_secret
 
     plugin :csrf, raise: true
-    plugin :flash
     plugin :dry_view
     plugin :error_handler
+    plugin :flash
     plugin :multi_route
 
     route do |r|
@@ -30,6 +30,16 @@ module <%= config[:camel_cased_app_name] %>
     error do |e|
       self.class[:rack_monitor].instrument(:error, exception: e)
       raise e
+    end
+
+    # Request-specific options for dry-view context object
+    def view_context_options
+      {
+        flash:        flash,
+        csrf_token:   Rack::Csrf.token(request.env),
+        csrf_metatag: Rack::Csrf.metatag(request.env),
+        csrf_tag:     Rack::Csrf.tag(request.env),
+      }
     end
 
     load_routes!

--- a/lib/dry/web/roda/templates/flat_project/web.rb.tt
+++ b/lib/dry/web/roda/templates/flat_project/web.rb.tt
@@ -15,6 +15,7 @@ module <%= config[:camel_cased_app_name] %>
     plugin :csrf, raise: true
     plugin :flash
     plugin :dry_view
+    plugin :error_handler
     plugin :multi_route
 
     route do |r|

--- a/lib/dry/web/roda/templates/flat_project/web.rb.tt
+++ b/lib/dry/web/roda/templates/flat_project/web.rb.tt
@@ -15,6 +15,7 @@ module <%= config[:camel_cased_app_name] %>
     plugin :csrf, raise: true
     plugin :flash
     plugin :dry_view
+    plugin :multi_route
 
     route do |r|
       # Enable this after writing your first web/routes/ file

--- a/lib/dry/web/roda/templates/subapp/web.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/web.rb.tt
@@ -16,6 +16,7 @@ module <%= config[:camel_cased_umbrella_name] %>
       plugin :csrf, raise: true
       plugin :flash
       plugin :dry_view
+      plugin :error_handler
       plugin :multi_route
 
       route do |r|

--- a/lib/dry/web/roda/templates/subapp/web.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/web.rb.tt
@@ -16,6 +16,7 @@ module <%= config[:camel_cased_umbrella_name] %>
       plugin :csrf, raise: true
       plugin :flash
       plugin :dry_view
+      plugin :multi_route
 
       route do |r|
         # Enable this after writing your first web/routes/ file

--- a/lib/dry/web/roda/templates/subapp/web.rb.tt
+++ b/lib/dry/web/roda/templates/subapp/web.rb.tt
@@ -14,9 +14,9 @@ module <%= config[:camel_cased_umbrella_name] %>
       use Rack::Session::Cookie, key: "<%= config[:underscored_umbrella_name] %>.<%= config[:underscored_project_name] %>.session", secret: self["core.settings"].session_secret
 
       plugin :csrf, raise: true
-      plugin :flash
       plugin :dry_view
       plugin :error_handler
+      plugin :flash
       plugin :multi_route
 
       route do |r|
@@ -26,6 +26,16 @@ module <%= config[:camel_cased_umbrella_name] %>
         r.root do
           r.view "welcome"
         end
+      end
+
+      # Request-specific options for dry-view context object
+      def view_context_options
+        {
+          flash:        flash,
+          csrf_token:   Rack::Csrf.token(request.env),
+          csrf_metatag: Rack::Csrf.metatag(request.env),
+          csrf_tag:     Rack::Csrf.tag(request.env),
+        }
       end
 
       load_routes!

--- a/lib/dry/web/roda/templates/umbrella_project/web.rb.tt
+++ b/lib/dry/web/roda/templates/umbrella_project/web.rb.tt
@@ -7,6 +7,8 @@ module <%= config[:camel_cased_app_name] %>
       config.container = Container
     end
 
+    plugin :error_handler
+
     route do |r|
       r.run <%= config[:camel_cased_app_name] %>::Main::Web.freeze.app
     end

--- a/lib/roda/plugins/dry_view.rb
+++ b/lib/roda/plugins/dry_view.rb
@@ -2,8 +2,6 @@ class Roda
   module RodaPlugins
     module DryView
       def self.load_dependencies(app)
-        app.plugin :csrf
-        app.plugin :flash
         app.plugin :flow
       end
 
@@ -13,12 +11,7 @@ class Roda
         end
 
         def view_context_options
-          {
-            flash:        flash,
-            csrf_token:   Rack::Csrf.token(request.env),
-            csrf_metatag: Rack::Csrf.metatag(request.env),
-            csrf_tag:     Rack::Csrf.tag(request.env),
-          }
+          {}
         end
       end
 


### PR DESCRIPTION
Move Roda dependencies from `Dry::Web::Roda::Application` base class and `dry_view` plugin into the generated `Web` classes in new projects. This keeps the base `D::W::Roda::Application` base class and `dry_view` plugin focused on their core jobs, and surfaces much more of the web behaviour into a place where application authors can see it and control it.

Fixes #63