### PR TITLE
Support Roda v3

### DIFF
--- a/dry-web-roda.gemspec
+++ b/dry-web-roda.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "dry-configurable", "~> 0.2"
   spec.add_runtime_dependency "inflecto", "~> 0.0"
-  spec.add_runtime_dependency "roda", "~> 2.14"
+  spec.add_runtime_dependency "roda", "~> 2.14", "< 4.0"
   spec.add_runtime_dependency "roda-flow", "~> 0.3"
   spec.add_runtime_dependency "thor", "~> 0.19"
 


### PR DESCRIPTION
The latest Roda version is v3.1.0, but this gem is still using v2.