### PR TITLE
Add ability to define a custom view key resolver

### DIFF
--- a/lib/roda/plugins/dry_view.rb
+++ b/lib/roda/plugins/dry_view.rb
@@ -13,12 +13,16 @@ class Roda
         def view_context_options
           {}
         end
+
+        def view_key(name)
+          "views.#{name}"
+        end
       end
 
       module RequestMethods
         def view(name, options = {})
           options = {context: scope.view_context}.merge(options)
-          is to: "views.#{name}", call_with: [options]
+          is to: scope.view_key(name), call_with: [options]
         end
       end
     end


### PR DESCRIPTION
This allows the user to determine how views are resolved, useful for custom directory structures such as `lib/{umbrella_name}/{app_name}/{action_name}/view.rb` rather than `lib/{umbrella_name}/{app_name}/views/{action_name}.rb`