### PR TITLE
Add workaround for shotgun when using High Siera (MacOSX)

### DIFF
--- a/lib/dry/web/roda/templates/README.md.tt
+++ b/lib/dry/web/roda/templates/README.md.tt
@@ -5,8 +5,16 @@ Welcome! You’ve generated an app using dry-web-roda.
 ## First steps
 
 1. Run `bundle`
-1. Review `.env` & `.env.test` (and make a copy to e.g. `.example.env` if you want example settings checked in)
-1. Run `bundle exec rake db:create`
-1. Add your own steps to `bin/setup`
-1. Run the app with `bundle exec shotgun -p 3000 -o 0.0.0.0 config.ru`
-1. Initialize git with `git init` and make your initial commit
+2. Review `.env` & `.env.test` (and make a copy to e.g. `.example.env` if you want example settings checked in)
+3. Run `bundle exec rake db:create`
+4. Add your own steps to `bin/setup`
+5. Run the app with `bundle exec shotgun -p 3000 -o 0.0.0.0 config.ru`
+   Shotgun is only compatible with systems that support fork(2) (probably just MRI on POSIX systems).
+
+   [This article on macOS High Sierra's issues with this][fork-on-high-sierra] mentions a workaround:
+   `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`
+
+6. Initialize git with `git init` and make your initial commit
+
+
+[fork-on-high-sierra]: https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/


### PR DESCRIPTION
@timriley @solnic I decided to have a new fresh update for my Mac. 
When installing dry-web-roda and generated a new project I stumble upon this error:

```
bundle exec shotgun -p 3000 -o 0.0.0.0 config.ru
== Shotgun/Puma on http://0.0.0.0:3000/
Puma starting in single mode...
* Version 3.11.0 (ruby 2.4.2-p198), codename: Love Song
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://0.0.0.0:3000
Use Ctrl-C to stop
objc[17241]: +[__NSPlaceholderDictionary initialize] may have been in progress in another thread when fork() was called.
objc[17241]: +[__NSPlaceholderDictionary initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
2018-01-17 10:47:23 +0100: Rack app error handling request { GET / }
#<EOFError: end of file reached>
```
Doing some research I found a couple of threads and articles.

I thought it might be a good idea to add this to the `README` of newly generated projects.

Another solution does not use `shotgun` but I think the auto-reloading part is important.

