### PR TITLE
Use latest version of dry-system for generated apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'dry-events', git: 'https://github.com/dry-rb/dry-events.git', branch: 'master'
-gem 'dry-monitor', git: 'https://github.com/dry-rb/dry-monitor.git', branch: 'master'
-gem 'dry-system', git: 'https://github.com/dry-rb/dry-system.git', branch: 'master'
-gem 'dry-web', git: 'https://github.com/dry-rb/dry-web.git', branch: 'master'
-
 gem 'pry'
 gem 'byebug', platform: :mri
 gem 'codeclimate-test-reporter', platform: :rbx
@@ -23,10 +18,12 @@ gem "rom-sql", "~> 2.1"
 gem "dry-matcher", "~> 0.6.0"
 gem "dry-monads", "~> 0.3"
 gem "dry-struct", "~> 0.3"
+gem "dry-system", "~> 0.9"
 gem "dry-transaction", "~> 0.10"
 gem "dry-types", "~> 0.12"
 gem "dry-validation", "~> 0.11"
 gem "dry-view", "~> 0.3"
+gem "dry-web", "~> 0.8"
 gem "slim"
 gem "pry-byebug", platform: :mri
 gem "capybara"

--- a/lib/dry/web/roda/templates/Gemfile
+++ b/lib/dry/web/roda/templates/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "rake"
 
 # Web framework
-gem "dry-system", "~> 0.8"
+gem "dry-system", "~> 0.9"
 gem "dry-web", "~> 0.7"
 gem "dry-web-roda", "~> 0.7"
 gem "puma"

--- a/lib/dry/web/roda/templates/settings.rb.tt
+++ b/lib/dry/web/roda/templates/settings.rb.tt
@@ -1,6 +1,6 @@
 <%= config[:camel_cased_app_name] %>::Container.boot :settings, from: :system do
   before :init do
-    ::Kernel.require "types"
+    require "types"
   end
 
   settings do


### PR DESCRIPTION
@timriley @solnic 

Make generated new apps use the latest version of `dry-system`