### PR TITLE
Replace shotgun with rerun

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'codeclimate-test-reporter', platform: :rbx
 gem "puma"
 gem "rack_csrf"
 gem "rack", ">= 2.0"
-gem "shotgun", ">= 0.9.2"
 gem "pg"
 gem "rom", "~> 4.0"
 gem "rom-factory", "~> 0.5"

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'codeclimate-test-reporter', platform: :rbx
 # Generated application dependencies
 gem "puma"
 gem "rack_csrf"
+gem "rerun"
 gem "rack", ">= 2.0"
 gem "pg"
 gem "rom", "~> 4.0"

--- a/dry-web-roda.gemspec
+++ b/dry-web-roda.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-configurable", "~> 0.2"
   spec.add_runtime_dependency "inflecto", "~> 0.0"
   spec.add_runtime_dependency "roda", "~> 2.14"
-  spec.add_runtime_dependency "roda-flow", "~> 0.3"
+  spec.add_runtime_dependency "roda-flow", "~> 0.3.1"
   spec.add_runtime_dependency "thor", "~> 0.19"
 
   spec.add_development_dependency "aruba"

--- a/lib/dry/web/roda/templates/Gemfile
+++ b/lib/dry/web/roda/templates/Gemfile
@@ -10,7 +10,7 @@ gem "puma"
 gem "rack_csrf"
 
 gem "rack", ">= 2.0"
-gem "shotgun", ">= 0.9.2"
+gem "rerun"
 
 # Database persistence
 gem "pg"

--- a/lib/dry/web/roda/templates/README.md.tt
+++ b/lib/dry/web/roda/templates/README.md.tt
@@ -5,8 +5,8 @@ Welcome! You’ve generated an app using dry-web-roda.
 ## First steps
 
 1. Run `bundle`
-1. Review `.env` & `.env.test` (and make a copy to e.g. `.example.env` if you want example settings checked in)
-1. Run `bundle exec rake db:create`
-1. Add your own steps to `bin/setup`
-1. Run the app with `bundle exec shotgun -p 3000 -o 0.0.0.0 config.ru`
-1. Initialize git with `git init` and make your initial commit
+2. Review `.env` & `.env.test` (and make a copy to e.g. `.example.env` if you want example settings checked in)
+3. Run `bundle exec rake db:create`
+4. Add your own steps to `bin/setup`
+5. Run the app with `bundle exec rerun -- rackup --port 4000 config.ru`
+6. Initialize git with `git init` and make your initial commit

--- a/spec/support/app.rb
+++ b/spec/support/app.rb
@@ -26,7 +26,7 @@ module RSpec
         end
       end
 
-      def run_app(host: "0.0.0.0", port: "30333", timeout: 5)
+      def run_app(host: "0.0.0.0", port: "30333", timeout: 10)
         cmd = "bundle exec rackup -o 0.0.0.0 -p #{port} config.ru"
         out = Tempfile.new("dry-web-roda-out")
 


### PR DESCRIPTION
@solnic I know we said to use `entr` and added to `dry-web`, but since it will need some development time and everyone who is coming new to `dry-web-roda` with the latest OSX version will face an error with shotgun. I say let's do a quick patch and will work in the meantime for adding `entr` to `dry-web`