### PR TITLE
Update roda version

### DIFF
--- a/dry-web-roda.gemspec
+++ b/dry-web-roda.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "dry-configurable", "~> 0.2"
   spec.add_runtime_dependency "inflecto", "~> 0.0"
-  spec.add_runtime_dependency "roda", "~> 2.14"
-  spec.add_runtime_dependency "roda-flow", "~> 0.3.1"
+  spec.add_runtime_dependency "roda", "~> 3.0"
+  spec.add_runtime_dependency "roda-flow", "~> 0.3"
   spec.add_runtime_dependency "thor", "~> 0.19"
 
   spec.add_development_dependency "aruba"

--- a/lib/roda/plugins/dry_view.rb
+++ b/lib/roda/plugins/dry_view.rb
@@ -22,7 +22,7 @@ class Roda
       module RequestMethods
         def view(name, options = {})
           options = {context: scope.view_context}.merge(options)
-          is to: scope.view_key(name), call_with: [options]
+          on to: scope.view_key(name), call_with: [options]
         end
       end
     end


### PR DESCRIPTION
#81 

This PR update `roda` version to be compatible with the latest version of `roda-flow`, which is updated to work with the latest version of `roda` to avoid having issues with the routing wildcard
[forum](https://discourse.dry-rb.org/t/dry-web-roda-roda-flow-plugin-causing-routing-wildcard/461)
https://github.com/AMHOL/roda-flow/commit/f3f00bff0e07525a1cda59e5a29f61e71795e7cf
https://github.com/jeremyevans/roda/blob/3.4.0/lib/roda.rb#L836

I have talked with @alejandrobabio who have a couple of apps so we can test the change and make sure everything still working