### PR TITLE
Add bundler/setup require to boot files in generated project

### DIFF
--- a/lib/dry/web/roda/templates/flat_project/boot.rb.tt
+++ b/lib/dry/web/roda/templates/flat_project/boot.rb.tt
@@ -1,3 +1,5 @@
+require "bundler/setup"
+
 begin
   require "pry-byebug"
 rescue LoadError

--- a/lib/dry/web/roda/templates/umbrella_project/boot.rb.tt
+++ b/lib/dry/web/roda/templates/umbrella_project/boot.rb.tt
@@ -1,3 +1,5 @@
+require "bundler/setup"
+
 begin
   require "pry-byebug"
 rescue LoadError


### PR DESCRIPTION
We already `require "bundler/setup"` in 2 key entry points for our generated apps:

1. `Rakefile`
2. `bin/console`

We may as well add this to the third key entry point for our app: the umbrella container boot file.

This should allow the app to boot (in a properly configured environment) without `bundle exec`.

Resolves #79