### PR TITLE
Scope rerun dependency to development environment

### DIFF
--- a/lib/dry/web/roda/templates/Gemfile
+++ b/lib/dry/web/roda/templates/Gemfile
@@ -10,7 +10,6 @@ gem "puma"
 gem "rack_csrf"
 
 gem "rack", ">= 2.0"
-gem "rerun"
 
 # Database persistence
 gem "pg"
@@ -29,6 +28,10 @@ gem "slim"
 
 group :development, :test do
   gem "pry-byebug", platform: :mri
+end
+
+group :development do
+  gem "rerun"
 end
 
 group :test do


### PR DESCRIPTION
As far as I know, we don't need `rerun` neither in production, where application should be rebooted on deploy, nor in test, where the application is usually booted on demand.