### PR TITLE
Make types available in tests

### DIFF
--- a/lib/dry/web/roda/templates/spec/spec_helper.rb.tt
+++ b/lib/dry/web/roda/templates/spec/spec_helper.rb.tt
@@ -8,6 +8,7 @@ Dir[SPEC_ROOT.join("support/*.rb").to_s].each(&method(:require))
 Dir[SPEC_ROOT.join("shared/*.rb").to_s].each(&method(:require))
 
 require SPEC_ROOT.join("../system/<%= config[:underscored_project_name] %>/container")
+require SPEC_ROOT.join("../lib/types")
 
 RSpec.configure do |config|
   config.disable_monkey_patching!


### PR DESCRIPTION
I made this PR in a hurry. I found that I didn't have access to the types module in my tests, while I do have in development. It fixes the issue, but I'm not sure if there is a better way to integrate it.