### PR TITLE
Change Database Cleaner strategy

### DIFF
--- a/lib/dry/web/roda/templates/spec/db_spec_helper.rb.tt
+++ b/lib/dry/web/roda/templates/spec/db_spec_helper.rb.tt
@@ -6,7 +6,7 @@ Dir[SPEC_ROOT.join("support/db/*.rb").to_s].each(&method(:require))
 Dir[SPEC_ROOT.join("shared/db/*.rb").to_s].each(&method(:require))
 
 require "database_cleaner"
-DatabaseCleaner[:sequel, connection: Test::DatabaseHelpers.db].strategy = :truncation
+DatabaseCleaner[:sequel, connection: Test::DatabaseHelpers.db].strategy = :transaction
 
 RSpec.configure do |config|
   config.include Test::DatabaseHelpers


### PR DESCRIPTION
I've an API project with 1700+ tests and it's growing. It used to take 15 to 20 minutes to run the complete suite. So I wanted to avoid running the suite at all cost. After a single change as suggested in this PR, the time dropped to 40 seconds. There's still a `truncation` strategy in the before suite hook. But when the tests start to run, `transaction` strategy is good enough.