### PR TITLE
Allow bundler >= 1.7, so 2.x can work

### DIFF
--- a/dry-web-roda.gemspec
+++ b/dry-web-roda.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "thor", "~> 0.19"
 
   spec.add_development_dependency "aruba"
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "capybara", "~> 2.5"


### PR DESCRIPTION
Notably this leads to job failures in CI where Bundler 2.0.1 is installed.