### PR TITLE
CI: Use 2.6.3, jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ rvm:
   - 2.5.5
   - 2.4.5
   - 2.3.8
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
 matrix:
   allow_failures:
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
 notifications:
   email: false
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 script:
   - ./script/ci
 rvm:
-  - 2.6.2
+  - 2.6.3
   - 2.5.5
   - 2.4.5
   - 2.3.8


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html)