### PR TITLE
Upgrade Thor dependency

### DIFF
--- a/dry-web-roda.gemspec
+++ b/dry-web-roda.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-inflector", "~> 0.2"
   spec.add_runtime_dependency "roda", "~> 3.0"
   spec.add_runtime_dependency "roda-flow", "~> 0.4"
-  spec.add_runtime_dependency "thor", "~> 0.19"
+  spec.add_runtime_dependency "thor", "~> 1.0"
 end

--- a/project.yml
+++ b/project.yml
@@ -11,4 +11,4 @@ gemspec:
     - [dry-inflector, "~> 0.2"]
     - [roda, "~> 3.0"]
     - [roda-flow, "~> 0.4"]
-    - [thor, "~> 0.19"]
+    - [thor, "~> 1.0"]


### PR DESCRIPTION
We use `dry-web-roda`. We also use [other gems]. We are running into upgrade issues because newer gems depend on `thor ~> 1.0` which conflicts with the Thor version dependency of `dry-web-roda`. This PR upgrades the Thor dependency in `dry-web-roda`. 